### PR TITLE
Mpi/add user to device ssh function

### DIFF
--- a/scripts/factory-common-install/sh-lib/app_current_device_ssh.sh
+++ b/scripts/factory-common-install/sh-lib/app_current_device_ssh.sh
@@ -152,6 +152,7 @@ uninstall_factory_tools_from_device() {
 deploy_file_to_device() {
   local local_f="$1"
   local remote_f="$2"
+  local user="${3:-root}"
 
   local local_dirname
   local_dirname="$(dirname "$local_f")"
@@ -165,7 +166,7 @@ deploy_file_to_device() {
   build_scp_port_args_for_ssh_port_a "scp_port_args" "$device_ssh_port"
 
   run_cmd_as_device_root "mkdir -m 700 -p '$local_dirname'"
-  scp "${scp_port_args[@]}" "${local_f}" "root@${device_hostname}:${remote_f}"
+  scp "${scp_port_args[@]}" "${local_f}" "${user}@${device_hostname}:${remote_f}"
 }
 
 

--- a/scripts/factory-common-install/sh-lib/app_current_device_ssh.sh
+++ b/scripts/factory-common-install/sh-lib/app_current_device_ssh.sh
@@ -170,8 +170,9 @@ deploy_file_to_device() {
 
 
 retrieve_file_from_device() {
-  local local_f="$1"
-  local remote_f="$2"
+  local local_f="${1?}"
+  local remote_f="${2?}"
+  local user="${3:-root}"
 
   local local_dirname
   local_dirname="$(dirname "$local_f")"
@@ -186,7 +187,7 @@ retrieve_file_from_device() {
 
   mkdir -p "$local_dirname"
   chmod 700 "$local_dirname"
-  scp "${scp_port_args[@]}" "root@${device_hostname}:${remote_f}" "${local_f}"
+  scp "${scp_port_args[@]}" "${user}@${device_hostname}:${remote_f}" "${local_f}"
 }
 
 


### PR DESCRIPTION
Added a third arg to deploy_file_to_device and retrieve_file_from_device function to be able to set the user. If no user are defined, the root one will be used.